### PR TITLE
Webdriver: added --bail options for MochaJS. Actually isn't --bail use.

### DIFF
--- a/bin/webdriver
+++ b/bin/webdriver
@@ -32,6 +32,7 @@ program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage '<testCase> [options]'
   .option '-c, --capabilities <capability>', "for example '#{DEFAULT_CAPABILITIES}' - #{DEFAULT_CAPABILITIES} is default value"
+  .option '-b, --bail', "bail after first test failure (Mochajs)"
 
 program.parse process.argv
 
@@ -48,7 +49,15 @@ process.config.CONFIG = process.config.ABSOLUTE_PATH + '/config.cson'
     if ( args.length > 1 ) or ( args.length is 0)
       testRunnerEvent.emit 'missingTestCase'
 
+    # add mochajs params to execString
+    execString = ''
+    mochajsParams = ['--bail']
+
+    for mParams in mochajsParams
+      execString += " #{mParams}" if program[mParams.replace('--','')]
+
     cap = program.capabilities
+    process.env.EXEC_STRING = execString
     process.env.CAPABILITIES = if cap then cap else DEFAULT_CAPABILITIES
     process.env.CAPABILITIES_PATH = process.config.CAPABILITIES_PATH
     process.env.PAGE_OBJECTS_PATH = process.config.PAGE_OBJECTS_PATH

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,7 +1,0 @@
---reporter spec
---ui bdd
---compilers coffee:coffee-script/register
---require coffee-script/register
---timeout 70000
---slow 2000
---bail

--- a/runTest.coffee
+++ b/runTest.coffee
@@ -10,10 +10,14 @@ async.waterfall [
       cb null
 
   (cb) ->
-    mochaOpts = " --opts #{__dirname}/mocha.opts"
     mochaString = """
     #{__dirname}/node_modules/.bin/mocha #{__dirname}/tests/blank.coffee \
-    #{mochaOpts}
+    --reporter spec \
+    --ui bdd \
+    --compilers coffee:coffee-script/register \
+    --require coffee-script/register \
+    --timeout 70000 \
+    #{process.env.EXEC_STRING}
     """
     exec mochaString, (error, stdout, stderr) ->
       console.error error if error


### PR DESCRIPTION
mocha.opts was removed and mochajs options added:
--reporter spec
--ui bdd
--compilers coffee:coffee-script/register
--require coffee-script/register
--timeout 70000

Options timeout will be in some next revision configurable with some default value as well as reporter.

How to use:

./node_modules/.bin/webdriver <someTestCase> [--bail|-b]
