### PR TITLE
Webdriver: added --timeout options for MochaJS.

### DIFF
--- a/bin/webdriver
+++ b/bin/webdriver
@@ -28,11 +28,16 @@ testRunnerEvent.on 'missingConfigCson', ->
   console.log ''
   process.exit 0
 
+testRunnerEvent.on 'wrongConfiguration', (explain) ->
+  console.error "  ------------------------- \n  Sorry, #{explain}. \n -------------------------"
+  process.exit 0
+
 program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage '<testCase> [options]'
   .option '-c, --capabilities <capability>', "for example '#{DEFAULT_CAPABILITIES}' - #{DEFAULT_CAPABILITIES} is default value"
   .option '-b, --bail', "bail after first test failure (Mochajs)"
+  .option '-t, --timeout <ms>', 'set test-case timeout in milliseconds [2000] (Mochajs)'
 
 program.parse process.argv
 
@@ -51,10 +56,35 @@ process.config.CONFIG = process.config.ABSOLUTE_PATH + '/config.cson'
 
     # add mochajs params to execString
     execString = ''
-    mochajsParams = ['--bail']
+    mochajsParams = [
+      name: '--bail'
+      required: no
+    ,
+      name: '--timeout'
+      required: yes
+      minValue: ms = 5000
+      default: ms = 10000
+    ]
 
-    for mParams in mochajsParams
-      execString += " #{mParams}" if program[mParams.replace('--','')]
+    for switcher in mochajsParams
+
+      programOpt = program[switcher.name.replace('--','')]
+
+      # set default values
+      programOpt = switcher.default if !programOpt? && switcher.required is yes
+
+      if programOpt
+
+        # rules of switchers
+        if switcher.name is '--timeout'
+          message = "#{switcher.name} must be greater than #{switcher.minValue}"
+          testRunnerEvent.emit 'wrongConfiguration',message if programOpt < switcher.minValue
+
+        # add key
+        execString += " #{switcher.name}"
+
+        # and value. Example 2000ms for --timeout switcher
+        execString += " #{programOpt}" if !isNaN parseInt programOpt
 
     cap = program.capabilities
     process.env.EXEC_STRING = execString

--- a/bin/webdriver
+++ b/bin/webdriver
@@ -8,7 +8,7 @@ testRunnerEvent = new EventEmitter()
 DEFAULT_CAPABILITIES = 'chrome'
 
 # events
-testRunnerEvent.on 'missingTestCase', ->
+missingTestCase = ->
   console.error '  ------------------------- \n  Sorry, test case missing. \n ', '-------------------------'
   console.log '  Examples:'
   console.log ''
@@ -19,18 +19,18 @@ testRunnerEvent.on 'missingTestCase', ->
   console.log "    $ ./node_modules/test-stack-webdriver/bin/webdriver someTestCase -c #{DEFAULT_CAPABILITIES}"
   console.log ''
   program.help()
-  process.exit 0
+  process.exit 1
 
-testRunnerEvent.on 'missingConfigCson', ->
+missingConfigCson = ->
   console.error '  ------------------------- \n  Sorry, /config.cson missing. \n ', '-------------------------'
   console.log ''
   console.log '  You must create in root directory cson.config. More information on https://github.com/test-stack/webdriver'
   console.log ''
-  process.exit 0
+  process.exit 1
 
 testRunnerEvent.on 'wrongConfiguration', (explain) ->
   console.error "  ------------------------- \n  Sorry, #{explain}. \n -------------------------"
-  process.exit 0
+  process.exit 1
 
 program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
@@ -47,20 +47,19 @@ process.config.CONFIG = process.config.ABSOLUTE_PATH + '/config.cson'
 
 (
   fs.exists process.config.CONFIG, (exists) ->
-    testRunnerEvent.emit 'missingConfigCson' if !exists
+    missingConfigCson() if !exists
     require('cson-config').load process.config.CONFIG
 
     args = program.args
-    if ( args.length > 1 ) or ( args.length is 0)
-      testRunnerEvent.emit 'missingTestCase'
+    missingTestCase() if ( args.length > 1 ) or ( args.length is 0)
 
     # add mochajs params to execString
     execString = ''
     mochajsParams = [
-      name: '--bail'
+      name: 'bail'
       required: no
     ,
-      name: '--timeout'
+      name: 'timeout'
       required: yes
       minValue: ms = 5000
       default: ms = 10000
@@ -68,7 +67,7 @@ process.config.CONFIG = process.config.ABSOLUTE_PATH + '/config.cson'
 
     for switcher in mochajsParams
 
-      programOpt = program[switcher.name.replace('--','')]
+      programOpt = program[switcher.name]
 
       # set default values
       programOpt = switcher.default if !programOpt? && switcher.required is yes
@@ -76,12 +75,12 @@ process.config.CONFIG = process.config.ABSOLUTE_PATH + '/config.cson'
       if programOpt
 
         # rules of switchers
-        if switcher.name is '--timeout'
-          message = "#{switcher.name} must be greater than #{switcher.minValue}"
+        if switcher.name is 'timeout'
+          message = "--#{switcher.name} must be greater than #{switcher.minValue}"
           testRunnerEvent.emit 'wrongConfiguration',message if programOpt < switcher.minValue
 
         # add key
-        execString += " #{switcher.name}"
+        execString += " --#{switcher.name}"
 
         # and value. Example 2000ms for --timeout switcher
         execString += " #{programOpt}" if !isNaN parseInt programOpt

--- a/runTest.coffee
+++ b/runTest.coffee
@@ -16,7 +16,6 @@ async.waterfall [
     --ui bdd \
     --compilers coffee:coffee-script/register \
     --require coffee-script/register \
-    --timeout 70000 \
     #{process.env.EXEC_STRING}
     """
     exec mochaString, (error, stdout, stderr) ->


### PR DESCRIPTION
How to use:
./node_modules/.bin/webdriver <someTestCase> [-t | --timeout] <ms>

mochajsParams variable is array with objects. Every object has name of switcher, required and in case --timeout switcher properties minValue and default.
Property/switcher --timeout must be defined. In case if will be undefined, will be automatically set default value form mochajsParams. Added rules for --timeout property, that --property must be greather than 5000ms.

This part of webdriver must be refactored. All source code with solutions switchers 3rd-party.
